### PR TITLE
review of candidate -01

### DIFF
--- a/draft-reddy-add-delegated-credentials-01.xml
+++ b/draft-reddy-add-delegated-credentials-01.xml
@@ -261,20 +261,20 @@
 
         <section anchor="forwarder_m" title="Delegated Certificate Issuance">
           <t>The encrypted DNS forwarder is hosted on a CPE and provisioned by
-          a service (e.g., ACS) in the operator's network. Each CPE has a
+          a service (e.g., ACS) in the operator's network. Each CPE is assigned a
           unique FQDN (e.g., "cpe-12345.example.com" where 12345 is a unique
-          number). The unique FQDN MUST NOT carry any Personally Identifiable
+          number). It is NOT RECOMMENDED that such an FQDN carries any Personally Identifiable
           Information (PII) or device identification details like the customer
           number or device's serial number. The CPE generates a public and
           private key-pair, builds a certificate signing request (CSR), and
-          sends the CSR to a service in the vendor managing the CPE. Upoon
+          sends the CSR to a service in the operator managing the CPE. Upon
           receipt of the CSR, the operator's service can utilize Automatic
           Certificate Management Environment (ACME) <xref target="RFC8555" />
           to automate certificate management functions such as domain
           validation procedure, certificate issuance, and certificate
           revocation.</t>
 
-          <t>The challenge with this technique is the service will have to
+          <t>The challenge with this technique is that the service will have to
           communicate with the CA to issue certificates for millions of CPEs.
           If an external CA is unable to issue a certificate in time or
           replace an expired certificate, the service would no longer be able
@@ -471,11 +471,11 @@
       </t>
     </section>
 
-    <section anchor="Design" title="Design Rationle">
-      <t>Alternate solutions and limitations are discussed below:</t>
+    <section anchor="Design" title="Design Rationale">
+      <t>Alternate solutions and their limitations are discussed below:</t>
 
       <t><list style="symbols">
-          <t>The service managing the CPEs could get a CA certificate with
+          <t>A service managing the CPEs could get a CA certificate with
           name constraints extension (Section 4.2.1.10 of <xref
           target="RFC5280" />) and the service would in-turn act as an ACME
           server to provision end-entity certificates on CPEs. <list
@@ -484,25 +484,24 @@
               although <xref target="RFC5280" /> was standardized way back in
               2008. </t>
 
-              <t>Pro: Avoids changing TLS client and server (e.g., stunnel,
+              <t>Pro: Avoids changing TLS client and server (e.g., stunnel or
               openssl).</t>
             </list></t>
 
-          <t><xref target="RFC9115" /> defines a profile of the Automatic
-          Certificate Management Environment (ACME) protocol for generating
-          Delegated certificates. It allows the CPEs to request from the
+          <t><xref target="RFC9115" /> defines a profile of the ACME protocol for generating
+          Delegated certificates. It allows the CPEs to request from a
           service managing the CPEs, acting as a profiled ACME server, a
-          certificate for a delegated identity -- i.e., one belonging to the
+          certificate for a delegated identity, i.e., one belonging to the
           service. The service then uses the ACME protocol (with the
           extensions described in <xref target="RFC8739" />) to request
-          issuance of a Short-Term, Automatically Renewed (STAR) certificate
+          issuance of a short-term, Automatically Renewed (STAR) certificate
           for the same delegated identity. The generated short-term
-          certificate is automatically renewed by the ACME Certification
-          Authority (CA), is periodically fetched by the CPEs, and is used to
+          certificate is automatically renewed by the ACME CA,
+          is periodically fetched by the CPEs, and is used to
           act as encrypted DNS forwarders. The service can end the delegation
-          at any time by simply instructing the CA to stop the automatic
+          at any time by instructing the CA to stop the automatic
           renewal and letting the certificate expire shortly thereafter. Star
-          certificates requires support by CAs but requires no changes to the
+          certificates requires support by CAs but does not require changes to the
           deployed TLS ecosystem.<list style="symbols">
               <t>Con: Star certificates require support by CAs.</t>
 
@@ -534,7 +533,7 @@
     </section>
 
     <section title="Acknowledgements">
-      <t>Thanks to Neil Cook, Martin Thomson and Michael Richardson for the
+      <t>Thanks to Neil Cook, Martin Thomson, and Michael Richardson for the
       discussion and comments. .</t>
     </section>
   </middle>


### PR DESCRIPTION
MUST NOT on the PII is not a protocol reco, but a deployment one. The operation won't break if that MUST NOT is not followed. Reworded accordingly.